### PR TITLE
Change TERMINAL_NAME to app.devsuite.Ptyxis

### DIFF
--- a/nautilus-open-in-ptyxis.py
+++ b/nautilus-open-in-ptyxis.py
@@ -8,7 +8,7 @@ from gi import require_version
 require_version("Nautilus", "4.0")
 require_version("Gtk", "4.0")
 
-TERMINAL_NAME = "org.gnome.Ptyxis.Devel"
+TERMINAL_NAME = "app.devsuite.Ptyxis"
 
 import logging
 import os


### PR DESCRIPTION
Ptyxis is now on [Flathub](https://flathub.org/apps/app.devsuite.Ptyxis) and the new app ID is `app.devsuite.Ptyxis`.