### PR TITLE
Patch Nautilus 4.1

### DIFF
--- a/nautilus-open-in-ptyxis.py
+++ b/nautilus-open-in-ptyxis.py
@@ -5,7 +5,11 @@ import urllib.parse
 
 from gi import require_version
 
-require_version("Nautilus", "4.0")
+try:
+    require_version("Nautilus", "4.1")
+except ValueError:
+    require_version("Nautilus", "4.0")
+
 require_version("Gtk", "4.0")
 
 TERMINAL_NAME = "app.devsuite.Ptyxis"


### PR DESCRIPTION
This patch allows the extension to work with both Nautilus 4.0 and 4.1 by using a fallback `require_version` call. Without this, the extension fails to load on systems where only Nautilus 4.1 is available.